### PR TITLE
Use the new native headless mode for more realistic browser fingerprinting

### DIFF
--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -76,7 +76,7 @@ def browserSetup(isMobile: bool, user_agent: str = PC_USER_AGENT) -> WebDriver:
     options.add_experimental_option("useAutomationExtension", False)
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
     if ARGS.headless and ARGS.account_browser is None:
-        options.add_argument("--headless")
+        options.add_argument("--headless=new")
     options.add_argument('log-level=3')
     options.add_argument("--start-maximized")
     if platform.system() == 'Linux':


### PR DESCRIPTION
Newer versions of Chromium have an option for an improved native headless mode that runs a full version of the browser without visible UI instead of the minimal browser implementation that was previously used in headless. Taking advantage of this will make the fingerprint of the bot more realistic and make detection less likely.

Blog with details: https://antoinevastel.com/bot%20detection/2023/02/19/new-headless-chrome.html

Tested and the options change works correctly in both Edge and Chrome.