### PR TITLE
Add no-images, shuffle and no-webdriver-manager options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can use the simple installation guide made for Windows 10/11 devices who pla
         <li>Use optional arguments</li>
           <ul>
             <li><code>--headless</code> You can use this argument to run the script in headless mode.</li>
+            <li><code>--no-images</code> Prevent images from loading to increase performance.</li>
+            <li><code>--shuffle</code> Randomize the order in which accounts are farmed.</li>
             <li><code>--redeem</code> Enable auto-redeem rewards based on accounts.json goals.</li>
             <li><code>--calculator</code> Opens GUI calculator with custom options. When using this flag the script will not run.</li>
             <li><code>--session</code> Use this argument to create session for each account.</li>

--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ You can use the simple installation guide made for Windows 10/11 devices who pla
             <li><code>--discord WEBHOOK_URL</code> Use this argument to send logs to your Discord server through webhook.</li>
             <li><code>--skip-unusual</code> Click on skip for 5 days on unusual activity detection.</li>
             <li><code>--edge</code> Use Microsoft Edge webdriver instead of Chrome.</li>
-            <li><code>--on-finish ACTION</code> Action to perform on finish from one of the following: shutdown, sleep, hibernate, exit.</li>
             <li><code>--skip-shopping</code> Skips MSN shopping game.</li>
+            <li><code>--no-webdriver-manager</code> Use system installed webdriver instead of webdriver-manager.</li>
+            <li><code>--on-finish ACTION</code> Action to perform on finish from one of the following: shutdown, sleep, hibernate, exit.</li>
             <li>For example type in your terminal <code>python ms_rewards_farmer.py --everyday 14:30 --fast --session</code> You don't need to use all of arguments.</li>
           </ul>
         <li>Run the script normally that session and headless disabled.</li>

--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -2158,6 +2158,7 @@ def loadAccounts():
                  "\n[ACCOUNT] Edit with your credentials and save, then press any key to continue...")
         input()
         ACCOUNTS = json.load(open(ACCOUNTS_PATH, "r"))
+    finally:
         if ARGS.shuffle:
             random.shuffle(ACCOUNTS)
 

--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -115,9 +115,9 @@ def browserSetup(isMobile: bool, user_agent: str = PC_USER_AGENT, proxy: str = N
         options.add_argument("--no-sandbox")
         options.add_argument("--disable-dev-shm-usage")
     if ARGS.edge:
-        browser = webdriver.Edge(service=Service(EdgeChromiumDriverManager().install()), options=options)
+        browser = ARGS.no_webdriver_manager and webdriver.Edge(options=options) or webdriver.Edge(service=Service(EdgeChromiumDriverManager().install()), options=options)
     else:
-        browser = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+        browser = ARGS.no_webdriver_manager and webdriver.Chrome(options=options) or webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
     return browser
 
 
@@ -1545,6 +1545,11 @@ def argumentParser():
                         help="Randomize the order in which accounts are farmed.",
                         action="store_true",
                         required=False)
+    parser.add_argument("--no-webdriver-manager",
+                        help="Use system installed webdriver instead of webdriver-manager.",
+                        action="store_true",
+                        required=False)
+
 
     args = parser.parse_args()
     if args.superfast or args.fast:

--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -93,6 +93,8 @@ def browserSetup(isMobile: bool, user_agent: str = PC_USER_AGENT, proxy: str = N
              "webrtc.ip_handling_policy": "disable_non_proxied_udp",
              "webrtc.multiple_routes_enabled": False,
              "webrtc.nonproxied_udp_enabled": False}
+    if ARGS.no_images:
+        prefs["profile.managed_default_content_settings.images"] = 2
     if ARGS.account_browser:
         prefs["detach"] = True
     if proxy is not None:
@@ -1535,6 +1537,14 @@ def argumentParser():
                         help="Skip MSN shopping game (useful for people living in regions which do not support MSN Shopping.",
                         action="store_true",
                         required=False)
+    parser.add_argument("--no-images",
+                        help="Prevent images from loading to increase performance.",
+                        action="store_true",
+                        required=False)
+    parser.add_argument("--shuffle",
+                        help="Randomize the order in which accounts are farmed.",
+                        action="store_true",
+                        required=False)
 
     args = parser.parse_args()
     if args.superfast or args.fast:
@@ -2150,6 +2160,8 @@ def farmer():
     """function that runs other functions to farm."""
     global ERROR, MOBILE, CURRENT_ACCOUNT, STARTING_POINTS  # pylint: disable=global-statement
     try:
+        if ARGS.shuffle:
+            random.shuffle(ACCOUNTS)
         for account in ACCOUNTS:
             CURRENT_ACCOUNT = account['username']
             if CURRENT_ACCOUNT in FINISHED_ACCOUNTS:

--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -2158,14 +2158,14 @@ def loadAccounts():
                  "\n[ACCOUNT] Edit with your credentials and save, then press any key to continue...")
         input()
         ACCOUNTS = json.load(open(ACCOUNTS_PATH, "r"))
+        if ARGS.shuffle:
+            random.shuffle(ACCOUNTS)
 
 
 def farmer():
     """function that runs other functions to farm."""
     global ERROR, MOBILE, CURRENT_ACCOUNT, STARTING_POINTS  # pylint: disable=global-statement
     try:
-        if ARGS.shuffle:
-            random.shuffle(ACCOUNTS)
         for account in ACCOUNTS:
             CURRENT_ACCOUNT = account['username']
             if CURRENT_ACCOUNT in FINISHED_ACCOUNTS:

--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -115,9 +115,9 @@ def browserSetup(isMobile: bool, user_agent: str = PC_USER_AGENT, proxy: str = N
         options.add_argument("--no-sandbox")
         options.add_argument("--disable-dev-shm-usage")
     if ARGS.edge:
-        browser = ARGS.no_webdriver_manager and webdriver.Edge(options=options) or webdriver.Edge(service=Service(EdgeChromiumDriverManager().install()), options=options)
+        browser = webdriver.Edge(options=options) if ARGS.no_webdriver_manager else webdriver.Edge(service=Service(EdgeChromiumDriverManager().install()), options=options)
     else:
-        browser = ARGS.no_webdriver_manager and webdriver.Chrome(options=options) or webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+        browser = webdriver.Chrome(options=options) if ARGS.no_webdriver_manager else webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
     return browser
 
 
@@ -1549,7 +1549,6 @@ def argumentParser():
                         help="Use system installed webdriver instead of webdriver-manager.",
                         action="store_true",
                         required=False)
-
 
     args = parser.parse_args()
     if args.superfast or args.fast:


### PR DESCRIPTION
* `--no-images` should substantially improve performance for below-average connections. I don't know if this can increase the odds of accounts getting banned though.

* `--shuffle` aims to make the order of account farming random. It makes more sense to me that accounts are farmed in a random fashion so it feels more 'human'.

* `--no-webdriver-manager` forces the program to use system installed webdriver. This is a must when running the bot in certain ARM Linux servers.

Hit me up if you find any problems with my code!