### PR TITLE
Fix auto-redeem non clickable error

### DIFF
--- a/ms_rewards_farmer.py
+++ b/ms_rewards_farmer.py
@@ -22,7 +22,7 @@ from selenium import webdriver
 from selenium.common.exceptions import (ElementNotInteractableException, NoAlertPresentException,
                                         NoSuchElementException, SessionNotCreatedException, TimeoutException,
                                         UnexpectedAlertPresentException, JavascriptException,
-                                        ElementNotVisibleException)
+                                        ElementNotVisibleException, ElementClickInterceptedException)
 from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
@@ -2082,9 +2082,9 @@ def setRedeemGoal(browser: WebDriver, goal: str):
             else:
                 prGreen("[GOAL SETTER] New account goal set successfully!")
 
-    except NoSuchElementException as e:
+    except (NoSuchElementException, ElementClickInterceptedException) as exc:
         prRed("[GOAL SETTER] Ran into an exception trying to redeem!")
-        prRed(str(e))
+        prRed(str(exc))
         return
     finally:
         browser.get("https://rewards.microsoft.com/")
@@ -2102,7 +2102,7 @@ def redeemGoal(browser: WebDriver):
                 value="/html/body/div[1]/div[2]/main/div/ui-view/mee-rewards-dashboard/main/div/mee-rewards-redeem-info-card/div/mee-card-group/div/div[1]/mee-card/div/card-content/mee-rewards-redeem-goal-card/div/div[2]/div/a[1]",
             ).click()
             time.sleep(random.uniform(5, 7))
-        except NoSuchElementException:
+        except (NoSuchElementException, ElementClickInterceptedException):
             browser.find_element(
                 By.XPATH,
                 value="/html/body/div[1]/div[2]/main/div/ui-view/mee-rewards-dashboard/main/div/mee-rewards-redeem-info-card/div/mee-card-group/div/div[1]/mee-card/div/card-content/mee-rewards-redeem-goal-card/div/div[2]/div/a[1]",
@@ -2118,9 +2118,9 @@ def redeemGoal(browser: WebDriver):
                     By.XPATH, value=f'//*[@id="redeem-pdp_{id}"]'
                 ).click()
                 time.sleep(random.uniform(5, 7))
-            except NoSuchElementException:
+            except (NoSuchElementException, ElementClickInterceptedException):
                 browser.find_element(
-                    By.XPATH, value=f'//*[@id="redeem-pdp_{id}"]/span[1]'
+                    By.XPATH, value="/html/body/div[1]/div[2]/main/div[2]/div[2]/div[3]/a[2]"
                 ).click()
             # If a cookie consent container is present, we need to accept
             # those cookies to be able to redeem the reward
@@ -2132,10 +2132,10 @@ def redeemGoal(browser: WebDriver):
                 browser.find_element(
                     By.XPATH, value='//*[@id="redeem-checkout-review-confirm"]').click()
                 time.sleep(random.uniform(2, 4))
-            except NoSuchElementException:
+            except (NoSuchElementException, ElementClickInterceptedException):
                 browser.find_element(
                     By.XPATH, value='//*[@id="redeem-checkout-review-confirm"]/span[1]').click()
-        except NoSuchElementException as exc:
+        except (NoSuchElementException, ElementClickInterceptedException) as exc:
             browser.get("https://rewards.microsoft.com/")
             prRed("[REDEEM] Ran into an exception trying to redeem!")
             prRed(str(exc))
@@ -2150,7 +2150,7 @@ def redeemGoal(browser: WebDriver):
                 updateLogs()
                 cleanLogs()
                 return
-        except NoSuchElementException:
+        except (NoSuchElementException, ElementClickInterceptedException):
             pass
         finally:
             time.sleep(random.uniform(2, 4))
@@ -2164,7 +2164,7 @@ def redeemGoal(browser: WebDriver):
                 updateLogs()
                 cleanLogs()
                 return
-        except NoSuchElementException:
+        except (NoSuchElementException, ElementClickInterceptedException):
             pass
         prGreen(f"[REDEEM] {CURRENT_ACCOUNT} card redeemed!")
         LOGS[CURRENT_ACCOUNT]['Auto redeem'] = 'Redeemed!'
@@ -2172,7 +2172,7 @@ def redeemGoal(browser: WebDriver):
         cleanLogs()
         global auto_redeem_counter  # pylint: disable=global-statement
         auto_redeem_counter += 1
-    except NoSuchElementException as exc:
+    except (NoSuchElementException, ElementClickInterceptedException) as exc:
         prRed("[REDEEM] Ran into an exception trying to redeem!")
         prRed(str(exc))
         return


### PR DESCRIPTION
Selenium wasn't able to click a button during the auto-redeem process and crashed.

This fix adds a fallback using the full XPATH of the element.